### PR TITLE
fix: inline source maps

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
 	"fixed": [["@midl/*"]],
 	"linked": [],
 	"access": "public",
-	"baseBranch": "next",
+	"baseBranch": "main",
 	"updateInternalDependencies": "patch",
 	"ignore": ["e2e", "@midl/docs", "@midl/rune-etcher"]
 }

--- a/.changeset/funny-lizards-complain.md
+++ b/.changeset/funny-lizards-complain.md
@@ -1,0 +1,13 @@
+---
+"@midl/executor-react": patch
+"@midl/hardhat-deploy": patch
+"@midl/satoshi-kit": patch
+"@midl/connectors": patch
+"@midl/playwright": patch
+"@midl/executor": patch
+"@midl/react": patch
+"@midl/core": patch
+"@midl/node": patch
+---
+
+fix: inline source maps

--- a/packages/connectors/tsconfig.cjs.json
+++ b/packages/connectors/tsconfig.cjs.json
@@ -11,7 +11,6 @@
 		"module": "CommonJS",
 		"moduleResolution": "node",
 		"outDir": "./dist/cjs",
-		"sourceMap": true,
 		"noImplicitAny": false
 	}
 }

--- a/packages/connectors/tsconfig.esm.json
+++ b/packages/connectors/tsconfig.esm.json
@@ -10,7 +10,6 @@
 		"target": "esnext",
 		"module": "esnext",
 		"outDir": "./dist/esm",
-		"sourceMap": true,
 		"declaration": true,
 		"declarationDir": "./dist/types"
 	}

--- a/packages/connectors/tsconfig.json
+++ b/packages/connectors/tsconfig.json
@@ -3,6 +3,8 @@
 	"include": ["./src/**/*.ts"],
 	"compilerOptions": {
 		"moduleResolution": "Bundler",
+		"sourceMap": true,
+		"inlineSources": true,
 		"baseUrl": ".",
 		"paths": {
 			"~/*": ["./src/*"]

--- a/packages/core/tsconfig.cjs.json
+++ b/packages/core/tsconfig.cjs.json
@@ -11,7 +11,6 @@
 		"module": "CommonJS",
 		"moduleResolution": "node",
 		"outDir": "./dist/cjs",
-		"sourceMap": true,
 		"noImplicitAny": false
 	}
 }

--- a/packages/core/tsconfig.esm.json
+++ b/packages/core/tsconfig.esm.json
@@ -10,7 +10,6 @@
 		"target": "esnext",
 		"module": "esnext",
 		"outDir": "./dist/esm",
-		"sourceMap": true,
 		"declaration": true,
 		"declarationDir": "./dist/types"
 	}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -4,6 +4,8 @@
 	"compilerOptions": {
 		"moduleResolution": "Bundler",
 		"baseUrl": ".",
+		"sourceMap": true,
+		"inlineSources": true,
 		"paths": {
 			"~/*": ["./src/*"]
 		},

--- a/packages/executor-react/tsconfig.cjs.json
+++ b/packages/executor-react/tsconfig.cjs.json
@@ -10,7 +10,6 @@
 		"target": "es2020",
 		"module": "CommonJS",
 		"moduleResolution": "node",
-		"outDir": "./dist/cjs",
-		"sourceMap": true
+		"outDir": "./dist/cjs"
 	}
 }

--- a/packages/executor-react/tsconfig.esm.json
+++ b/packages/executor-react/tsconfig.esm.json
@@ -9,7 +9,6 @@
 	"compilerOptions": {
 		"target": "esnext",
 		"module": "esnext",
-		"sourceMap": true,
 		"declaration": true,
 		"declarationDir": "./dist/types",
 		"outDir": "./dist/esm"

--- a/packages/executor-react/tsconfig.json
+++ b/packages/executor-react/tsconfig.json
@@ -4,6 +4,8 @@
 	"compilerOptions": {
 		"baseUrl": ".",
 		"jsx": "react-jsx",
+		"sourceMap": true,
+		"inlineSources": true,
 		"paths": {
 			"~/*": ["./src/*"]
 		},

--- a/packages/executor/tsconfig.cjs.json
+++ b/packages/executor/tsconfig.cjs.json
@@ -10,7 +10,6 @@
 		"target": "es2020",
 		"module": "CommonJS",
 		"moduleResolution": "node",
-		"outDir": "./dist/cjs",
-		"sourceMap": true
+		"outDir": "./dist/cjs"
 	}
 }

--- a/packages/executor/tsconfig.esm.json
+++ b/packages/executor/tsconfig.esm.json
@@ -9,7 +9,6 @@
 	"compilerOptions": {
 		"target": "esnext",
 		"module": "esnext",
-		"sourceMap": true,
 		"declaration": true,
 		"declarationDir": "./dist/types",
 		"outDir": "./dist/esm"

--- a/packages/executor/tsconfig.json
+++ b/packages/executor/tsconfig.json
@@ -3,6 +3,8 @@
 	"include": ["src/**/*.ts"],
 	"compilerOptions": {
 		"baseUrl": ".",
+		"sourceMap": true,
+		"inlineSources": true,
 		"paths": {
 			"~/*": ["./src/*"]
 		},

--- a/packages/hardhat-deploy/tsconfig.cjs.json
+++ b/packages/hardhat-deploy/tsconfig.cjs.json
@@ -11,7 +11,6 @@
 		"module": "CommonJS",
 		"moduleResolution": "node",
 		"outDir": "./dist/cjs",
-		"sourceMap": true,
 		"noImplicitAny": false
 	}
 }

--- a/packages/hardhat-deploy/tsconfig.esm.json
+++ b/packages/hardhat-deploy/tsconfig.esm.json
@@ -10,7 +10,6 @@
 		"target": "esnext",
 		"module": "esnext",
 		"outDir": "./dist/esm",
-		"sourceMap": true,
 		"declaration": true,
 		"declarationDir": "./dist/types",
 		"skipLibCheck": true

--- a/packages/hardhat-deploy/tsconfig.json
+++ b/packages/hardhat-deploy/tsconfig.json
@@ -4,6 +4,8 @@
 	"compilerOptions": {
 		"moduleResolution": "Bundler",
 		"baseUrl": ".",
+		"sourceMap": true,
+		"inlineSources": true,
 		"paths": {
 			"~/*": ["./src/*"]
 		},

--- a/packages/node/tsconfig.cjs.json
+++ b/packages/node/tsconfig.cjs.json
@@ -11,7 +11,6 @@
 		"module": "CommonJS",
 		"moduleResolution": "node",
 		"outDir": "./dist/cjs",
-		"sourceMap": true,
 		"noImplicitAny": false
 	}
 }

--- a/packages/node/tsconfig.esm.json
+++ b/packages/node/tsconfig.esm.json
@@ -10,7 +10,6 @@
 		"target": "esnext",
 		"module": "esnext",
 		"outDir": "./dist/esm",
-		"sourceMap": true,
 		"declaration": true,
 		"declarationDir": "./dist/types"
 	}

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -4,6 +4,8 @@
 	"compilerOptions": {
 		"moduleResolution": "Bundler",
 		"baseUrl": ".",
+		"sourceMap": true,
+		"inlineSources": true,
 		"paths": {
 			"~/*": ["./src/*"]
 		},

--- a/packages/playwright/tsconfig.build.json
+++ b/packages/playwright/tsconfig.build.json
@@ -8,6 +8,7 @@
 	],
 	"compilerOptions": {
 		"sourceMap": true,
+		"inlineSources": true,
 		"declaration": true,
 		"declarationDir": "./dist",
 		"outDir": "./dist"

--- a/packages/react/tsconfig.cjs.json
+++ b/packages/react/tsconfig.cjs.json
@@ -10,7 +10,6 @@
 		"target": "es2020",
 		"module": "CommonJS",
 		"moduleResolution": "node",
-		"outDir": "./dist/cjs",
-		"sourceMap": true
+		"outDir": "./dist/cjs"
 	}
 }

--- a/packages/react/tsconfig.esm.json
+++ b/packages/react/tsconfig.esm.json
@@ -9,7 +9,6 @@
 	"compilerOptions": {
 		"target": "esnext",
 		"module": "esnext",
-		"sourceMap": true,
 		"declaration": true,
 		"declarationDir": "./dist/types",
 		"outDir": "./dist/esm"

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -5,6 +5,8 @@
 		"baseUrl": ".",
 		"moduleResolution": "Bundler",
 		"jsx": "react-jsx",
+		"sourceMap": true,
+		"inlineSources": true,
 		"paths": {
 			"~/*": ["./src/*"]
 		},

--- a/packages/satoshi-kit/tsconfig.esm.json
+++ b/packages/satoshi-kit/tsconfig.esm.json
@@ -11,6 +11,7 @@
 		"target": "esnext",
 		"module": "esnext",
 		"sourceMap": true,
+		"inlineSources": true,
 		"declaration": true,
 		"declarationDir": "./dist/types",
 		"outDir": "./dist/esm"


### PR DESCRIPTION
Currently we don't include source code to the package. So inlining it will fix the error when bundlers can't find the sourcecode. 