### PR TITLE
test(core): broadcastTransaction

### DIFF
--- a/packages/core/src/__tests__/provider.ts
+++ b/packages/core/src/__tests__/provider.ts
@@ -1,0 +1,11 @@
+import { vi } from "vitest";
+import type { AbstractProvider } from "~/providers";
+
+export const mockProvider = {
+	broadcastTransaction: vi.fn(),
+	getUTXOs: vi.fn(),
+	getLatestBlockHeight: vi.fn(),
+	getFeeRate: vi.fn(),
+	getTransactionStatus: vi.fn(),
+	getTransactionHex: vi.fn(),
+} satisfies AbstractProvider;


### PR DESCRIPTION
This pull request refactors the tests for the `broadcastTransaction` action to use a new mock provider and simplifies the test setup by removing unnecessary dependencies and server initialization. The changes improve test isolation and clarity.

**Testing improvements:**

* Introduced a new `mockProvider` object in `packages/core/src/__tests__/provider.ts` that mocks the `AbstractProvider` interface using `vitest`'s `vi.fn()` for all required provider methods.
* Updated `broadcastTransaction.test.ts` to use `mockProvider` for provider mocking, removing reliance on `mockServer` and external connectors, which streamlines test setup and teardown.
* Simplified the test cases to directly mock provider behavior for both successful and failed broadcast scenarios, making the tests more focused and easier to maintain.