### PR TITLE
feat(hardhat-deploy): add customConnector support for connector injection

### DIFF
--- a/packages/hardhat-deploy/src/MidlHardhatEnvironment.ts
+++ b/packages/hardhat-deploy/src/MidlHardhatEnvironment.ts
@@ -147,11 +147,7 @@ export class MidlHardhatEnvironment {
 		let connector: ReturnType<typeof keyPairConnector>;
 
 		if (this.userConfig.customConnector) {
-			// Clone the connector to avoid mutating frozen Hardhat config
-			connector = Object.create(
-				Object.getPrototypeOf(this.userConfig.customConnector),
-				Object.getOwnPropertyDescriptors(this.userConfig.customConnector),
-			);
+			connector = this.userConfig.customConnector(accountIndex);
 		} else if (this.userConfig.mnemonic) {
 			connector = keyPairConnector({
 				mnemonic: this.userConfig.mnemonic,

--- a/packages/hardhat-deploy/src/type-extensions.ts
+++ b/packages/hardhat-deploy/src/type-extensions.ts
@@ -17,7 +17,7 @@ declare module "hardhat/types/config" {
 				string | "default",
 				{
 					mnemonic?: string;
-					customConnector?: ConnectorWithMetadata;
+					customConnector?: (accountIndex: number) => ConnectorWithMetadata;
 					confirmationsRequired?: number;
 					btcConfirmationsRequired?: number;
 					network?: string | BitcoinNetwork;


### PR DESCRIPTION
Allows users to provide their own connector via the `customConnector` config option instead of using the built-in mnemonic-based keyPairConnector.

This enables advanced use cases like hardware wallets, custom signing logic, or the fixedSecretKeyPairConnector for CREATE2 address consistency.