### PR TITLE
feat: support WIF and hex private keys in keypair connector

### DIFF
--- a/.changeset/young-insects-knock.md
+++ b/.changeset/young-insects-knock.md
@@ -1,0 +1,6 @@
+---
+"@midl/core": patch
+"@midl/node": patch
+---
+
+feat(node): support WIF and hex private keys in keyPair connector

--- a/packages/core/src/connectors/createConnector.ts
+++ b/packages/core/src/connectors/createConnector.ts
@@ -71,8 +71,15 @@ export const createConnector = <T extends Connector>(
 	return connector;
 };
 
-export type CreateConnectorFn<Params = void> = Params extends void
-	? (params?: { metadata?: UserMetadata }) => ConnectorWithMetadata<Connector>
-	: (
-			params: Params & { metadata?: UserMetadata },
-		) => ConnectorWithMetadata<Connector>;
+type WithMetadata = { metadata?: UserMetadata };
+
+type CreateConnectorFnNoParams = (
+	params?: WithMetadata,
+) => ConnectorWithMetadata<Connector>;
+type CreateConnectorFnWithParams<P> = (
+	params: P & WithMetadata,
+) => ConnectorWithMetadata<Connector>;
+
+export type CreateConnectorFn<Params = object> = [keyof Params] extends [never]
+	? CreateConnectorFnNoParams
+	: CreateConnectorFnWithParams<Params>;

--- a/packages/node/src/__tests__/keyPair.ts
+++ b/packages/node/src/__tests__/keyPair.ts
@@ -1,2 +1,9 @@
 export const __TEST__MNEMONIC__ =
 	"test test test test test test test test test test test junk";
+
+// Test private keys (corresponding to the same mnemonic for payment address)
+export const __TEST__PRIVATE_KEY_HEX__ =
+	"c87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3";
+
+export const __TEST__PRIVATE_KEY_WIF__ =
+	"cVpF924EspNh8KjYsfhgY96mmxvT6DgdWiTYMtMjuM74hJaU5psW";


### PR DESCRIPTION
This pull request adds support for using both WIF (Wallet Import Format) and raw hex private keys in the `keyPairConnector` for the `@midl/node` package, in addition to the existing mnemonic-based support. It also refactors the connector's parameter types for better flexibility and updates the test suite to cover the new functionality.

**Key changes:**

Private key support in `keyPairConnector`:
- The `keyPairConnector` now accepts either a mnemonic, an array of raw hex private keys, or an array of WIF private keys, allowing more flexible ways to initialize accounts. The connector will detect the key type and handle it appropriately. [[1]](diffhunk://#diff-ed820881b6ee9a4bdeb3e6f716204d5762324456d08521d11def48ae7fd581f1L34-R55) [[2]](diffhunk://#diff-ed820881b6ee9a4bdeb3e6f716204d5762324456d08521d11def48ae7fd581f1L241-R269) [[3]](diffhunk://#diff-ed820881b6ee9a4bdeb3e6f716204d5762324456d08521d11def48ae7fd581f1R278-R337)

Parameter and type refactoring:
- Refactored the connector's parameter types to accept either a mnemonic or private keys, and updated the type definitions to improve clarity and type safety. [[1]](diffhunk://#diff-ed820881b6ee9a4bdeb3e6f716204d5762324456d08521d11def48ae7fd581f1R278-R337) [[2]](diffhunk://#diff-d9aa0c9c27f24a7f62a15709ebe0c7eb981ed9e0a4936d628b3a9aab91a05ffdL74-R85)

Testing improvements:
- Added new test vectors for hex and WIF private keys, and extended the test suite in `keyPair.test.ts` to verify that the connector works correctly with these formats, including address derivation and message signing. [[1]](diffhunk://#diff-21638c9c37608118d69cdc4747d1ec50f3641452a381c19b174d5e1d8a899418R3-R9) [[2]](diffhunk://#diff-7469112fade70f0c06eff3b4778cbfef51a6eab5c09330d476640ca91822b560L15-R19) [[3]](diffhunk://#diff-7469112fade70f0c06eff3b4778cbfef51a6eab5c09330d476640ca91822b560R238-R335)

Changelog:
- Added a changeset entry documenting the new feature and patch release for both `@midl/core` and `@midl/node`.