### PR TITLE
feat(hardhat-deploy): improve dx for overrides & options args

### DIFF
--- a/.changeset/six-points-know.md
+++ b/.changeset/six-points-know.md
@@ -1,0 +1,5 @@
+---
+"@midl/hardhat-deploy": patch
+---
+
+feat(hardhat-deploy): improve overrides & options arguments for better DX

--- a/packages/hardhat-deploy/src/actions/deployContract.test.ts
+++ b/packages/hardhat-deploy/src/actions/deployContract.test.ts
@@ -283,13 +283,6 @@ describe("deployContract", () => {
 		};
 		mockReadArtifact.mockResolvedValue(mockArtifact);
 
-		const overrides = {
-			evmTransaction: {
-				value: 1000n,
-				gasLimit: 21000n,
-			},
-		};
-
 		const store = createStore();
 		await deployContract(
 			mockHre,
@@ -298,14 +291,17 @@ describe("deployContract", () => {
 			mockPublicClient,
 			"OverridesContract",
 			[],
-			{ overrides },
+			{
+				value: 1000n,
+				gas: 21000n,
+			},
 		);
 
 		expect(addTxIntention).toHaveBeenCalledWith(mockConfig, {
 			evmTransaction: {
 				data: "0xdeploydata",
 				value: 1000n,
-				gasLimit: 21000n,
+				gas: 21000n,
 				nonce: 5,
 				from: mockEvmAddress,
 			},
@@ -333,11 +329,7 @@ describe("deployContract", () => {
 			"CustomNonceContract",
 			[],
 			{
-				overrides: {
-					evmTransaction: {
-						nonce: customNonce,
-					},
-				},
+				nonce: customNonce,
 			},
 		);
 
@@ -365,11 +357,7 @@ describe("deployContract", () => {
 			"CustomFromContract",
 			[],
 			{
-				overrides: {
-					evmTransaction: {
-						from: customFrom,
-					},
-				},
+				from: customFrom,
 			},
 		);
 
@@ -414,6 +402,11 @@ describe("deployContract", () => {
 			store,
 			mockPublicClient,
 			"Contract2",
+			[],
+			{
+				value: 500n,
+			},
+			{},
 		);
 
 		expect(getContractAddress).toHaveBeenCalledWith({

--- a/packages/hardhat-deploy/src/actions/execute.test.ts
+++ b/packages/hardhat-deploy/src/actions/execute.test.ts
@@ -360,7 +360,7 @@ describe("execute", () => {
 			mockConfig,
 			[mockIntention, mockCompleteTx],
 			mockPublicClient,
-			undefined,
+			{},
 		);
 	});
 
@@ -418,7 +418,7 @@ describe("execute", () => {
 			mockConfig,
 			store,
 			mockPublicClient,
-			{ overrides },
+			overrides,
 		);
 
 		expect(finalizeBTCTransaction).toHaveBeenCalledWith(

--- a/packages/hardhat-deploy/src/actions/execute.ts
+++ b/packages/hardhat-deploy/src/actions/execute.ts
@@ -19,8 +19,7 @@ import type { MidlHardhatStore } from "~/actions/createStore";
 import { saveDeployment } from "~/actions/saveDeployment";
 import type { MidlNetworkConfig } from "~/type-extensions";
 
-export type ExecuteOptions = {
-	overrides?: FinalizeBTCTransactionOptions;
+export type ExecuteOptions = FinalizeBTCTransactionOptions & {
 	withdraw?: Withdrawal | boolean;
 };
 
@@ -30,8 +29,7 @@ export const execute = async (
 	config: Config,
 	store: StoreApi<MidlHardhatStore>,
 	publicClient: PublicClient,
-	options: ExecuteOptions = {
-		overrides: {},
+	{ withdraw, ...options }: ExecuteOptions = {
 		withdraw: false,
 	},
 ) => {
@@ -41,10 +39,10 @@ export const execute = async (
 		return null;
 	}
 
-	if (options.withdraw) {
+	if (withdraw) {
 		const completeTx = await addCompleteTxIntention(
 			config,
-			options.withdraw === true ? undefined : options.withdraw,
+			withdraw === true ? undefined : withdraw,
 		);
 
 		intentions.push(completeTx);
@@ -54,7 +52,7 @@ export const execute = async (
 		config,
 		intentions,
 		publicClient,
-		options.overrides,
+		options,
 	);
 
 	const signedTransactions: `0x07${string}`[] = [];

--- a/packages/hardhat-deploy/src/actions/readContract.test.ts
+++ b/packages/hardhat-deploy/src/actions/readContract.test.ts
@@ -220,7 +220,7 @@ describe("readContract", () => {
 			"Token",
 			"balanceOf",
 			["0x1111111111111111111111111111111111111111"],
-			{ overrides },
+			overrides,
 		);
 
 		expect(mockReadContractFn).toHaveBeenCalledWith({

--- a/packages/hardhat-deploy/src/actions/readContract.ts
+++ b/packages/hardhat-deploy/src/actions/readContract.ts
@@ -2,12 +2,10 @@ import type { HardhatRuntimeEnvironment } from "hardhat/types";
 import type { PublicClient, ReadContractParameters } from "viem";
 import { getDeployment } from "~/actions/getDeployment";
 
-export type ReadContractOptions = {
-	overrides?: Omit<
-		ReadContractParameters,
-		"address" | "functionName" | "abi" | "args"
-	>;
-};
+export type ReadContractOptions = Omit<
+	ReadContractParameters,
+	"address" | "functionName" | "abi" | "args"
+>;
 
 export const readContract = async (
 	hre: HardhatRuntimeEnvironment,
@@ -30,6 +28,6 @@ export const readContract = async (
 		functionName,
 		abi: artifact.abi,
 		args: args,
-		...options.overrides,
+		...options,
 	});
 };

--- a/packages/hardhat-deploy/src/actions/writeContract.test.ts
+++ b/packages/hardhat-deploy/src/actions/writeContract.test.ts
@@ -322,13 +322,6 @@ describe("writeContract", () => {
 			abi: mockArtifact.abi,
 		});
 
-		const overrides = {
-			evmTransaction: {
-				value: 1000n,
-				gasLimit: 50000n,
-			},
-		};
-
 		const store = createStore();
 		await writeContract(
 			mockHre,
@@ -338,7 +331,7 @@ describe("writeContract", () => {
 			"NFT",
 			"mint",
 			[],
-			{ overrides },
+			{ value: 1000n, gas: 50000n },
 		);
 
 		expect(addTxIntention).toHaveBeenCalledWith(mockConfig, {
@@ -347,7 +340,7 @@ describe("writeContract", () => {
 				data: "0xcalldata",
 				nonce: 5,
 				value: 1000n,
-				gasLimit: 50000n,
+				gas: 50000n,
 			},
 		});
 	});
@@ -374,11 +367,7 @@ describe("writeContract", () => {
 			"withdraw",
 			[],
 			{
-				overrides: {
-					evmTransaction: {
-						nonce: customNonce,
-					},
-				},
+				nonce: customNonce,
 			},
 		);
 
@@ -414,11 +403,7 @@ describe("writeContract", () => {
 			"delegate",
 			[],
 			{
-				overrides: {
-					evmTransaction: {
-						from: customFrom,
-					},
-				},
+				from: customFrom,
 			},
 		);
 

--- a/packages/hardhat-deploy/src/createMidlHardhatEnvironment.test.ts
+++ b/packages/hardhat-deploy/src/createMidlHardhatEnvironment.test.ts
@@ -210,6 +210,7 @@ describe("createMidlHardhatEnvironment", () => {
 			"MyContract",
 			args,
 			options,
+			{},
 		);
 	});
 
@@ -236,9 +237,10 @@ describe("createMidlHardhatEnvironment", () => {
 		await env.initialize();
 
 		const args = ["0x1234"];
-		const options = { overrides: { blockNumber: 123n } };
 
-		await env.read("Token", "balanceOf", args, options);
+		await env.read("Token", "balanceOf", args, {
+			blockNumber: 10n,
+		});
 
 		expect(readContract).toHaveBeenCalledWith(
 			mockHre,
@@ -246,7 +248,9 @@ describe("createMidlHardhatEnvironment", () => {
 			"Token",
 			"balanceOf",
 			args,
-			options,
+			{
+				blockNumber: 10n,
+			},
 		);
 	});
 
@@ -255,7 +259,7 @@ describe("createMidlHardhatEnvironment", () => {
 		await env.initialize();
 
 		const args = ["0x1234", 100];
-		const options = { overrides: {} };
+		const options = {};
 
 		await env.write("Token", "transfer", args, options);
 
@@ -268,6 +272,7 @@ describe("createMidlHardhatEnvironment", () => {
 			"transfer",
 			args,
 			options,
+			{},
 		);
 	});
 
@@ -412,7 +417,8 @@ describe("createMidlHardhatEnvironment", () => {
 			mockPublicClient,
 			"SimpleContract",
 			undefined,
-			undefined,
+			{},
+			{},
 		);
 	});
 
@@ -446,7 +452,8 @@ describe("createMidlHardhatEnvironment", () => {
 			"Token",
 			"pause",
 			undefined,
-			undefined,
+			{},
+			{},
 		);
 	});
 });

--- a/packages/hardhat-deploy/src/createMidlHardhatEnvironment.ts
+++ b/packages/hardhat-deploy/src/createMidlHardhatEnvironment.ts
@@ -3,10 +3,12 @@ import { getEVMAddress } from "@midl/executor";
 import type { HardhatRuntimeEnvironment } from "hardhat/types";
 import { http, type PublicClient, createPublicClient } from "viem";
 import {
+	type DeployContractIntentionOverrides,
 	type DeployContractOptions,
 	type DeploymentData,
 	type ExecuteOptions,
 	type ReadContractOptions,
+	type WriteContractEvmTransactionOverrides,
 	type WriteContractOptions,
 	createStore,
 	deleteDeployment,
@@ -51,7 +53,8 @@ export const createMidlHardhatEnvironment = (
 		deploy: async (
 			name: string,
 			args?: unknown[],
-			options?: DeployContractOptions,
+			options: DeployContractOptions = {},
+			overrides: DeployContractIntentionOverrides = {},
 		) => {
 			if (!config) {
 				throw new Error("Midl not initialized. Call initialize() first.");
@@ -65,6 +68,7 @@ export const createMidlHardhatEnvironment = (
 				name,
 				args,
 				options,
+				overrides,
 			);
 		},
 		execute: async (options?: ExecuteOptions) => {
@@ -97,7 +101,8 @@ export const createMidlHardhatEnvironment = (
 			name: string,
 			functionName: string,
 			args?: unknown[],
-			options?: WriteContractOptions,
+			evmTransactionOverrides: WriteContractEvmTransactionOverrides = {},
+			options: WriteContractOptions = {},
 		) => {
 			if (!config) {
 				throw new Error("Midl not initialized. Call initialize() first.");
@@ -110,6 +115,7 @@ export const createMidlHardhatEnvironment = (
 				name,
 				functionName,
 				args,
+				evmTransactionOverrides,
 				options,
 			);
 		},


### PR DESCRIPTION
This pull request refactors the way overrides and options are handled in the `@midl/hardhat-deploy` package to provide a more intuitive and developer-friendly experience. The main focus is on simplifying and clarifying the API for contract deployment, execution, reading, and writing by flattening and separating overrides and options arguments, and updating related tests and types accordingly. Fixes #270 

**API Improvements and Refactoring**

* Simplified and flattened the `overrides` and `options` arguments in the `deployContract`, `writeContract`, `readContract`, and `execute` functions, making them easier to use and reason about. The new approach separates EVM transaction overrides from other options and removes unnecessary nesting. [[1]](diffhunk://#diff-f7a428fdc62e83d8d0a2c9d4ad3ea3926414ca6ee25c9c35b0f2fb3b38c48206L24-L30) [[2]](diffhunk://#diff-f7a428fdc62e83d8d0a2c9d4ad3ea3926414ca6ee25c9c35b0f2fb3b38c48206L39-R39) [[3]](diffhunk://#diff-f7a428fdc62e83d8d0a2c9d4ad3ea3926414ca6ee25c9c35b0f2fb3b38c48206L60-R60) [[4]](diffhunk://#diff-f7a428fdc62e83d8d0a2c9d4ad3ea3926414ca6ee25c9c35b0f2fb3b38c48206L69-L78) [[5]](diffhunk://#diff-0ef5de5ae3ce35a9472d5ca81cb20f521fb864696ba71f0927a75dfa0aa9d5ffL13-R24) [[6]](diffhunk://#diff-0ef5de5ae3ce35a9472d5ca81cb20f521fb864696ba71f0927a75dfa0aa9d5ffR35) [[7]](diffhunk://#diff-0ef5de5ae3ce35a9472d5ca81cb20f521fb864696ba71f0927a75dfa0aa9d5ffL46-R52) [[8]](diffhunk://#diff-0ef5de5ae3ce35a9472d5ca81cb20f521fb864696ba71f0927a75dfa0aa9d5ffL56-L64) [[9]](diffhunk://#diff-c7ef38a1f3f0f2f195f93f52a2d9027a58d5bd43b968605039453f6c43d33a99L5-L10) [[10]](diffhunk://#diff-c7ef38a1f3f0f2f195f93f52a2d9027a58d5bd43b968605039453f6c43d33a99L33-R31) [[11]](diffhunk://#diff-9d6ae701f27c110ceb12f1525de258bf4bbb1dedef0497795f0d8c3f459944e0L22-R22) [[12]](diffhunk://#diff-9d6ae701f27c110ceb12f1525de258bf4bbb1dedef0497795f0d8c3f459944e0L33-R32) [[13]](diffhunk://#diff-9d6ae701f27c110ceb12f1525de258bf4bbb1dedef0497795f0d8c3f459944e0L44-R45) [[14]](diffhunk://#diff-9d6ae701f27c110ceb12f1525de258bf4bbb1dedef0497795f0d8c3f459944e0L57-R55) [[15]](diffhunk://#diff-54cba4e3b9e21c2b0ec42473baf6454cfc886f20d371e06a0931beb66bfbe37bR6-R11) [[16]](diffhunk://#diff-54cba4e3b9e21c2b0ec42473baf6454cfc886f20d371e06a0931beb66bfbe37bL54-R57)

**Test Updates**

* Updated all related tests to match the new argument structure, removing nested `overrides` objects and passing overrides directly where needed. This ensures the tests accurately reflect the new API and usage patterns. [[1]](diffhunk://#diff-a1d752b76cfa88ab36e8b8b6ffd34880e7e79222f05ce62c925bbcf0e3253438L286-L292) [[2]](diffhunk://#diff-a1d752b76cfa88ab36e8b8b6ffd34880e7e79222f05ce62c925bbcf0e3253438L301-R304) [[3]](diffhunk://#diff-a1d752b76cfa88ab36e8b8b6ffd34880e7e79222f05ce62c925bbcf0e3253438L336-L341) [[4]](diffhunk://#diff-a1d752b76cfa88ab36e8b8b6ffd34880e7e79222f05ce62c925bbcf0e3253438L368-L373) [[5]](diffhunk://#diff-a1d752b76cfa88ab36e8b8b6ffd34880e7e79222f05ce62c925bbcf0e3253438R405-R409) [[6]](diffhunk://#diff-f089e1b7d23af8956268d438e3a43bd150bcb132e58f4bcb56c4f6e531ce90f2L363-R363) [[7]](diffhunk://#diff-f089e1b7d23af8956268d438e3a43bd150bcb132e58f4bcb56c4f6e531ce90f2L421-R421) [[8]](diffhunk://#diff-7a874a2e89382676b8729a259213f230956f82d83dee6e257f38efc49a4a21afL223-R223) [[9]](diffhunk://#diff-4cf9353417144cf1ce60d7a706f9390a2382384b7e29663ece12c119ff15e860L325-L331) [[10]](diffhunk://#diff-4cf9353417144cf1ce60d7a706f9390a2382384b7e29663ece12c119ff15e860L341-R334) [[11]](diffhunk://#diff-4cf9353417144cf1ce60d7a706f9390a2382384b7e29663ece12c119ff15e860L350-R343) [[12]](diffhunk://#diff-4cf9353417144cf1ce60d7a706f9390a2382384b7e29663ece12c119ff15e860L377-L382) [[13]](diffhunk://#diff-4cf9353417144cf1ce60d7a706f9390a2382384b7e29663ece12c119ff15e860L417-L422) [[14]](diffhunk://#diff-4a1235c6ee6ed8bb6533ab9aadccec16a8a8594eb8c6799f73c3d2b9bf0c2729R213) [[15]](diffhunk://#diff-4a1235c6ee6ed8bb6533ab9aadccec16a8a8594eb8c6799f73c3d2b9bf0c2729L239-R253) [[16]](diffhunk://#diff-4a1235c6ee6ed8bb6533ab9aadccec16a8a8594eb8c6799f73c3d2b9bf0c2729L258-R262) [[17]](diffhunk://#diff-4a1235c6ee6ed8bb6533ab9aadccec16a8a8594eb8c6799f73c3d2b9bf0c2729R275) [[18]](diffhunk://#diff-4a1235c6ee6ed8bb6533ab9aadccec16a8a8594eb8c6799f73c3d2b9bf0c2729L415-R421) [[19]](diffhunk://#diff-4a1235c6ee6ed8bb6533ab9aadccec16a8a8594eb8c6799f73c3d2b9bf0c2729L449-R456)

**Developer Experience**

* The changeset documents the new feature, highlighting the improved handling of overrides and options for better developer experience (DX).