### PR TITLE
Fix broken faucet link in deploy-contract guide

### DIFF
--- a/apps/docs/midl/guides/deploy-contract.md
+++ b/apps/docs/midl/guides/deploy-contract.md
@@ -209,7 +209,7 @@ export default deploy;
 ## Deploy the Contract
 
 ::: warning
-Make sure you have Bitcoin on Regtest. You can claim some at the [faucet](https://faucet.midl.xyz) or by contacting us directly on [Discord](https://discord.com/invite/midl). To get your Bitcoin account address, you can run the following command:
+Make sure you have Bitcoin on Regtest. You can claim some at the [faucet](https://faucet.regtest.midl.xyz/) or by contacting us directly on [Discord](https://discord.com/invite/midl) and [telagram](t.me/midl_xyz) . To get your Bitcoin account address, you can run the following command:
 
 ```bash
 pnpm hardhat midl:address


### PR DESCRIPTION
## Summary
Fixed incorrect faucet URL in the "Deploy the Contract" guide documentation.

## Changes
- Updated faucet link from `https://faucet.midl.xyz/` to `https://faucet.regtest.midl.xyz/`
- Location: `/guides/deploy-contract` page, in the WARNING section about claiming Bitcoin on Regtest

## Issue
The current link (faucet.midl.xyz) returns a 404 error. Users following the guide to deploy their first contract cannot access the faucet to get test Bitcoin.

## Testing
- Verified the corrected link (faucet.regtest.midl.xyz) is accessible and working
- Confirmed this is the correct URL for claiming Regtest Bitcoin

## Impact
This fix will help new users successfully complete the deployment tutorial without getting stuck at the funding step.